### PR TITLE
Optimize lodash dependency size

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets":["es2015","react"]
+    "presets": ["es2015", "react"],
+    "plugins": ["lodash"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-web-animation",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
@@ -37,6 +37,7 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.2",
     "babel-loader": "^6.2.3",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
     "chai": "*",
@@ -45,6 +46,7 @@
     "enzyme": "^2.0.0",
     "eslint": "2.13.0",
     "eslint-plugin-mocha": "3.0.0",
+    "lodash-webpack-plugin": "^0.11.2",
     "mocha": "2.5.3",
     "react": ">=15.1.0",
     "react-addons-test-utils": ">=15.1.0",
@@ -57,9 +59,7 @@
     "react-dom": ">=0.14.0 <16.0.0"
   },
   "dependencies": {
-    "lodash.assign": "^4.0.3",
-    "lodash.groupby": "^4.2.0",
-    "lodash.isequal": "^4.1.0",
+    "lodash": "^4.17.4",
     "shortid": "^2.2.4"
   }
 }

--- a/src/animation.js
+++ b/src/animation.js
@@ -1,8 +1,9 @@
 import React, { Children, PropTypes } from 'react';
 import Animatable from './animatable';
-import assign from 'lodash.assign';
-import isEqual from 'lodash.isequal';
 import playable from './mixins/playable';
+
+const _assign = require('lodash/assign');
+const _isEqual = require('lodash/isEqual');
 
 /**
  * <Animation/> is a simple implementation of <Animatable/> and controls a single
@@ -31,7 +32,7 @@ class Animation extends Animatable {
         if (timing && keyframes) {
             const newTiming = Object.assign({}, timing);
 
-            if (!isEqual(keyframes, this.keyframes) || !isEqual(newTiming, this.timing)) {
+            if (!_isEqual(keyframes, this.keyframes) || !_isEqual(newTiming, this.timing)) {
                 this.timing = newTiming;
                 this.keyframes = keyframes;
                 // start the new animation with the new config
@@ -72,9 +73,9 @@ class Animation extends Animatable {
     }
 }
 
-assign(Animation.prototype, playable);
+_assign(Animation.prototype, playable);
 
-Animation.propTypes = assign({}, Animatable.propTypes, {
+Animation.propTypes = _assign({}, Animatable.propTypes, {
     onCancel: PropTypes.func,
     onFinish: PropTypes.func,
     onPause: PropTypes.func,

--- a/src/effect.js
+++ b/src/effect.js
@@ -1,9 +1,10 @@
 /* eslint no-unused-vars:0*/
 import React, { Component, Children, PropTypes } from 'react';
 import Animatable from './animatable';
-import isEqual from 'lodash.isequal';
-import assign from 'lodash.assign';
 import playable from './mixins/playable';
+
+const _assign = require('lodash/assign');
+const _isEqual = require('lodash/isEqual');
 
 /**
  * The Abstract <Effect/> component represents the behavior of a Grouped set of <Animatable/>
@@ -66,7 +67,7 @@ class Effect extends Component {
         let newFrameCache = Object.assign({}, this.buildFrameCache(nextProps));
         const { currentTime } = nextProps;
 
-        if (!isEqual(newFrameCache, this.frameCache)) {
+        if (!_isEqual(newFrameCache, this.frameCache)) {
             this.keyframeEffects = nextKeyframes;
             this.effect = this.getEffectFromKeyframes(nextKeyframes);
             this.startAnimation(nextProps);
@@ -112,7 +113,7 @@ class Effect extends Component {
         }, childElements);
     }
 }
-assign(Effect.prototype, playable);
+_assign(Effect.prototype, playable);
 
 Effect.defaultProps = {
     component: 'div'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var webpack = require('webpack');
+var LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
 var env = process.env.NODE_ENV;
 
 var reactExternal = {
@@ -40,6 +41,7 @@ var config = {
                 });
             }
         },
+        new LodashModuleReplacementPlugin(),
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(env)


### PR DESCRIPTION
- Use `babel-plugin-lodash` and `lodash-webpack-plugin`
- Import `isEqual` and `assign`, remove `groupBy` (not used)
- Bump up version to `0.1.3`

Before:
```
Hash: a270bfc4b3139ead0b1c
Version: webpack 1.14.0
Time: 1027ms
                 Asset   Size  Chunks             Chunk Names
react-web-animation.js  99 kB       0  [emitted]  main
    + 11 hidden modules
Hash: cf2f4056f2768d51e2b0
Version: webpack 1.14.0
Time: 1663ms
                     Asset   Size  Chunks             Chunk Names
react-web-animation.min.js  25 kB       0  [emitted]  main
    + 11 hidden modules
```
After:
```
Hash: f1b2bfec862b39fc5916
Version: webpack 1.14.0
Time: 1121ms
                 Asset     Size  Chunks             Chunk Names
react-web-animation.js  68.3 kB       0  [emitted]  main
    + 53 hidden modules
Hash: 649b44a523235bc63a35
Version: webpack 1.14.0
Time: 1555ms
                     Asset     Size  Chunks             Chunk Names
react-web-animation.min.js  18.9 kB       0  [emitted]  main
    + 53 hidden modules
```

For https://github.com/bringking/react-web-animation/issues/48