### PR TITLE
chore(repo): switch to prop-types

### DIFF
--- a/example/src/basic_sequence.js
+++ b/example/src/basic_sequence.js
@@ -85,7 +85,6 @@ export default class BasicSequence extends Component {
             It really does!
           </Animatable.div>
         </AnimationSequence>
-
       </div>
     </div>;
   }

--- a/package.json
+++ b/package.json
@@ -1,107 +1,108 @@
 {
-    "name": "react-web-animation",
-    "version": "0.0.0-development",
-    "main": "./lib/index.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/RinconStrategies/react-web-animation.git"
-    },
-    "keywords": [
-        "react",
-        "animation",
-        "web-animations-api"
+  "name": "react-web-animation",
+  "version": "0.0.0-development",
+  "main": "./lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RinconStrategies/react-web-animation.git"
+  },
+  "keywords": [
+    "react",
+    "animation",
+    "web-animations-api"
+  ],
+  "files": [
+    "dist",
+    "lib",
+    "src"
+  ],
+  "author": "Charles King <charlie@rinconstrategies.io> (http://github.com/bringking)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/RinconStrategies/react-web-animation/issues"
+  },
+  "homepage": "https://github.com/RinconStrategies/react-web-animation",
+  "scripts": {
+    "lint": "eslint src test",
+    "test": "NODE_ENV=test jest --coverage --no-cache",
+    "build:lib": "babel src --out-dir lib",
+    "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/react-web-animation.js",
+    "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/react-web-animation.min.js",
+    "build:all": "yarn build:lib && yarn build:umd && yarn build:umd:min",
+    "semantic-release": "semantic-release pre && yarn build:all && npm publish && semantic-release post"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.8.0",
+    "babel-core": "^6.8.0",
+    "babel-eslint": "^7.2.0",
+    "babel-jest": "^18.0.0",
+    "babel-loader": "^6.2.3",
+    "babel-plugin-lodash": "^3.2.11",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
+    "chai": "*",
+    "cross-env": "^3.2.4",
+    "cz-customizable": "^4.0.0",
+    "enzyme": "^2.0.0",
+    "eslint": "3.18.0",
+    "eslint-plugin-react": "^6.9.0",
+    "jest": "^19.0.2",
+    "jest-cli": "^18.0.0",
+    "lodash-webpack-plugin": "^0.11.2",
+    "react": ">=15.1.0",
+    "react-addons-test-utils": ">=15.1.0",
+    "react-dom": ">=15.1.0",
+    "semantic-release": "^6.3.2",
+    "source-map": "^0.5.4",
+    "webpack": "^2.3.1"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/!(*.test).js"
     ],
-    "files": [
-        "dist",
-        "lib",
-        "src"
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "dist/",
+      "lib/"
     ],
-    "author": "Charles King <charlie@rinconstrategies.io> (http://github.com/bringking)",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/RinconStrategies/react-web-animation/issues"
-    },
-    "homepage": "https://github.com/RinconStrategies/react-web-animation",
-    "scripts": {
-        "lint": "eslint src test",
-        "test": "NODE_ENV=test jest --coverage --no-cache",
-        "build:lib": "babel src --out-dir lib",
-        "build:umd": "cross-env NODE_ENV=development webpack src/index.js dist/react-web-animation.js",
-        "build:umd:min": "cross-env NODE_ENV=production webpack src/index.js dist/react-web-animation.min.js",
-        "build:all": "yarn build:lib && yarn build:umd && yarn build:umd:min",
-        "semantic-release": "semantic-release pre && yarn build:all && npm publish && semantic-release post"
-    },
-    "devDependencies": {
-        "babel-cli": "^6.8.0",
-        "babel-core": "^6.8.0",
-        "babel-eslint": "^7.2.0",
-        "babel-loader": "^6.2.3",
-        "babel-plugin-lodash": "^3.2.11",
-        "babel-preset-es2015": "^6.5.0",
-        "babel-preset-react": "^6.5.0",
-        "babel-plugin-transform-object-rest-spread": "^6.23.0",
-        "chai": "*",
-        "cross-env": "^3.2.4",
-        "cz-customizable": "^4.0.0",
-        "eslint-plugin-react": "^6.9.0",
-        "babel-jest": "^18.0.0",
-        "jest": "^19.0.2",
-        "jest-cli": "^18.0.0",
-        "enzyme": "^2.0.0",
-        "eslint": "3.18.0",
-        "lodash-webpack-plugin": "^0.11.2",
-        "react": ">=15.1.0",
-        "react-addons-test-utils": ">=15.1.0",
-        "react-dom": ">=15.1.0",
-        "semantic-release": "^6.3.2",
-        "source-map": "^0.5.4",
-        "webpack": "^2.3.1"
-    },
-    "jest": {
-        "collectCoverageFrom": [
-            "src/**/!(*.test).js"
-        ],
-        "coveragePathIgnorePatterns": [
-            "<rootDir>/node_modules/",
-            "dist/",
-            "lib/"
-        ],
-        "moduleFileExtensions": [
-            "js",
-            "jsx",
-            "json"
-        ],
-        "transform": {
-            "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
-        }
-    },
-    "release": {
-        "analyzeCommits": {
-            "path": "./release/analyze-commits.js",
-            "minorTypes": [
-                "fix",
-                "feat"
-            ],
-            "patchTypes": [
-                "refactor",
-                "docs"
-            ]
-        }
-    },
-    "config": {
-        "commitizen": {
-            "path": "node_modules/cz-customizable"
-        },
-        "cz-customizable": {
-            "config": ".cz-config.js"
-        }
-    },
-    "peerDependencies": {
-        "react": ">=0.14.0 <16.0.0",
-        "react-dom": ">=0.14.0 <16.0.0"
-    },
-    "dependencies": {
-        "lodash": "^4.17.4",
-        "shortid": "^2.2.4"
+    "moduleFileExtensions": [
+      "js",
+      "jsx",
+      "json"
+    ],
+    "transform": {
+      "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
     }
+  },
+  "release": {
+    "analyzeCommits": {
+      "path": "./release/analyze-commits.js",
+      "minorTypes": [
+        "fix",
+        "feat"
+      ],
+      "patchTypes": [
+        "refactor",
+        "docs"
+      ]
+    }
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-customizable"
+    },
+    "cz-customizable": {
+      "config": ".cz-config.js"
+    }
+  },
+  "peerDependencies": {
+    "react": ">=0.14.0 <16.0.0",
+    "react-dom": ">=0.14.0 <16.0.0",
+    "prop-types": "^15.5.6"
+  },
+  "dependencies": {
+    "lodash": "^4.17.4",
+    "shortid": "^2.2.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/RinconStrategies/react-web-animation.git"
+    "url": "https://github.com/bringking/react-web-animation.git"
   },
   "keywords": [
     "react",
@@ -16,12 +16,12 @@
     "lib",
     "src"
   ],
-  "author": "Charles King <charlie@rinconstrategies.io> (http://github.com/bringking)",
+  "author": "Charles King <bringking@gmail.com> (http://github.com/bringking)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/RinconStrategies/react-web-animation/issues"
+    "url": "https://github.com/bringking/react-web-animation/issues"
   },
-  "homepage": "https://github.com/RinconStrategies/react-web-animation",
+  "homepage": "https://github.com/bringking/react-web-animation",
   "scripts": {
     "lint": "eslint src test",
     "test": "NODE_ENV=test jest --coverage --no-cache",

--- a/src/animation.js
+++ b/src/animation.js
@@ -1,4 +1,5 @@
-import React, { Children, PropTypes } from 'react';
+import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 import Animatable from './animatable';
 import playable from './mixins/playable';
 

--- a/src/effect.js
+++ b/src/effect.js
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars:0*/
-import React, { Component, Children, PropTypes } from 'react';
-import Animatable from './animatable';
+import React, { Component, Children } from 'react';
+import PropTypes from 'prop-types';
 import playable from './mixins/playable';
 
 const _assign = require('lodash/assign');

--- a/src/utils/with_hoc_elements.test.js
+++ b/src/utils/with_hoc_elements.test.js
@@ -1,5 +1,6 @@
 /* global it, expect, describe */
-import { PropTypes, Component } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import withHocElements from './with_hoc_elements';
 import domElements from './dom_elements';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1907,6 +1907,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -4008,6 +4020,12 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types:
+  version "15.5.6"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.6.tgz#797a915b1714b645ebb7c5d6cc690346205bd2aa"
+  dependencies:
+    fbjs "^0.8.9"
 
 proto-list@~1.2.1:
   version "1.2.4"


### PR DESCRIPTION
To prepare for users switching to React 15.5.0, this PR removes the usage of `PropTypes` from React and uses the new `prop-types` package.