### PR TITLE
feat(repo): pass props on Effects to fix SVG

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -47,6 +47,17 @@
       transition: transform 250ms ease-in-out;
     }
 
+    .svg-group circle {
+      fill: none;
+      stroke-width: 1;
+      stroke-linecap: round;
+      transform-origin: center center;
+    }
+
+    .svg-group circle:nth-child(even) {
+      transform: rotate(5deg);
+    }
+
     @media (max-width: 768px) {
       .menu-button {
         display: inline;

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -8,6 +8,7 @@ import ParallaxStarfield from './parallax_starfield';
 import SpinningDots from './spinning_dots';
 import AnimateCss from './animate_css';
 import Scrolling from './scrolling';
+import SvgGroup from './svg_group';
 import Welcome from './welcome';
 
 export default class App extends Component {
@@ -71,6 +72,9 @@ export default class App extends Component {
             <li style={this.getListItemStyle()} onClick={this.closeMenu}>
               <Link to="/scrolling">Scrolling</Link>
             </li>
+            <li style={this.getListItemStyle()} onClick={this.closeMenu}>
+              <Link to="/svg-group">SVG Group</Link>
+            </li>
           </ul>
         </div>
         <div className="example-display">
@@ -82,6 +86,7 @@ export default class App extends Component {
             <Route path="/spinning-dots" component={SpinningDots} />
             <Route path="/animate-css" component={AnimateCss} />
             <Route path="/scrolling" component={Scrolling} />
+            <Route path="/svg-group" component={SvgGroup} />
             <Route component={Welcome} />
           </Switch>
         </div>

--- a/demo/src/svg_group.js
+++ b/demo/src/svg_group.js
@@ -1,0 +1,147 @@
+import React, { Component } from 'react';
+import { AnimationGroup, Animatable } from 'react-web-animation';
+
+export default class SvgGroup extends Component {
+  getKeyFrames() {
+    return [
+      { transform: 'scale(.1) rotate(0deg)', opacity: 0.1, offset: 0 },
+      { transform: 'scale(1.3) rotate(90deg)', opacity: 1, offset: 0.5 },
+      { transform: 'scale(1) rotate(0deg)', opacity: 1, offset: 1 },
+    ];
+  }
+
+  getTiming(duration) {
+    return {
+      duration,
+      easing: 'ease-in',
+      delay: 0,
+      iterations: 10,
+      direction: 'alternate',
+      fill: 'forwards',
+    };
+  }
+
+  render() {
+    return (
+      <div style={{ padding: '12px' }}>
+        <a href="https://github.com/RinconStrategies/react-web-animation/blob/master/demo/src/svg_group.js">
+          View Source
+        </a>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            pointerEvents: 'none',
+            fontWeight: 'bold',
+            fontSize: '4rem',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '12px',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+          }}
+        >
+          <AnimationGroup
+            component="svg"
+            viewBox="0 0 60 60"
+            className="svg-group"
+          >
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="10"
+              strokeDasharray="0.001, 1.745"
+              stroke="hsl(120, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4000)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="12"
+              strokeDasharray="0.001, 2.094"
+              stroke="hsl(108, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4100)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="14"
+              strokeDasharray="0.001, 2.443"
+              stroke="hsl(96, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4200)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="16"
+              strokeDasharray="0.001, 2.793"
+              stroke="hsl(84, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4300)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="18"
+              strokeDasharray="0.001, 3.142"
+              stroke="hsl(72, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4400)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="20"
+              strokeDasharray="0.001, 3.491"
+              stroke="hsl(60, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4500)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="22"
+              strokeDasharray="0.001, 3.840"
+              stroke="hsl(48, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4600)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="24"
+              strokeDasharray="0.001, 4.189"
+              stroke="hsl(36, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4700)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="26"
+              strokeDasharray="0.001, 4.538"
+              stroke="hsl(24, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4800)}
+            />
+            <Animatable.circle
+              cx="30"
+              cy="30"
+              r="28"
+              strokeDasharray="0.001, 4.887"
+              stroke="hsl(12, 100%, 50%)"
+              keyframes={this.getKeyFrames()}
+              timing={this.getTiming(4900)}
+            />
+          </AnimationGroup>
+        </div>
+      </div>
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
     "analyzeCommits": {
       "path": "./release/analyze-commits.js",
       "minorTypes": [
-        "fix",
         "feat"
       ],
       "patchTypes": [
+        "fix",
         "refactor",
         "docs"
       ]

--- a/src/effect.js
+++ b/src/effect.js
@@ -106,6 +106,7 @@ class Effect extends Component {
     return React.createElement(
       component,
       {
+        ...this.props,
         ref: node => {
           this.wrapper = node;
           if (getRef) {


### PR DESCRIPTION
This PR fixes #63 by passing the props onto the element so you can use SVG attrs like `viewBox` etc. It also adds an example to the demo site using an `AnimationGroup` as an `svg`