### PR TITLE
fix(repo): Guard against an undefined player

### DIFF
--- a/src/mixins/playable.js
+++ b/src/mixins/playable.js
@@ -12,8 +12,10 @@ export default {
     player.oncancel = props.onCancel;
   },
   detachHandlersFromPlayer(player) {
-    player.onfinish = null;
-    player.oncancel = null;
+    if (player) {
+      player.onfinish = null;
+      player.oncancel = null;
+    }
   },
   notifyHandlers(event) {
     const { player } = this.state;

--- a/src/mixins/playable.test.js
+++ b/src/mixins/playable.test.js
@@ -40,6 +40,10 @@ describe('playable', () => {
       expect(player.onfinish).toBe(null);
       expect(player.oncancel).toBe(null);
     });
+
+    it('will not throw exception on undefined player', () => {
+      playable.detachHandlersFromPlayer(undefined);
+    });
   });
 
   describe('notifyHandlers', () => {


### PR DESCRIPTION
I was running into a situation in an Animated.div where we were trying to detatch handlers while `player` was undefined causing an uncaught exception to be thrown.