### PR TITLE
Ensure name is provided to define() in UMD build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,12 @@ var config = {
         ]
     },
     output: {
-        library: 'ReactWebAnimation',
-        libraryTarget: 'umd'
+        library: {
+          root: 'ReactWebAnimation',
+          amd: 'react-web-animation',
+        },
+        libraryTarget: 'umd',
+        umdNamedDefine: true,
     },
     plugins: [
         new LodashModuleReplacementPlugin(),


### PR DESCRIPTION
RequireJS needs to know which name to register an AMD module under.  The name was previously mixing; this PR fixes that.